### PR TITLE
upgrade wechaty version to 0.1.5-SNAPSHOT

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,13 +19,7 @@
         <dependency>
             <groupId>io.github.wechaty</groupId>
             <artifactId>wechaty</artifactId>
-            <version>0.1.4-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.wechaty</groupId>
-            <artifactId>wechaty-puppet-hostie</artifactId>
-            <version>0.1.4-SNAPSHOT</version>
+            <version>0.1.5-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
1. upgrade wechaty version to 0.1.5-SNAPSHOT
2. remove manual hostie puppet implementation, because 0.1.5-SNAPSHOT has hostie puppet as default puppet implementation 